### PR TITLE
fix : isNaN -> Number.isNan(Number())

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ rtm.on('message', (message) => {
   const { channel } = message;
   const { text } = message;
 
-  if (!isNaN(text)) {
+  if (!Number.isNaN(Number(text))) {
     square(rtm, text, channel);
   } else {
     switch (text) {


### PR DESCRIPTION
Number.isNaN(text) -> text가 문자열이던 숫자던 false (NaN값이 아니다.) 따라서 챗봇에 숫자 입력시 정상 작동안함
Number.isNaN(Number(text)) -> text를 Number로 감싸주면 text값이 숫자가 아니면 NaN값이 됨